### PR TITLE
Ensure the timer is stopped before starting

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,12 +5,21 @@ const EventEmitter = require('events')
 function worker () {
   let timerId
 
+  function stop () {
+    clearInterval(timerId)
+    timerId = null
+  }
+
   self.onmessage = function (e) {
-    if (e.data === 'start') {
+    switch (e.data) {
+    case 'start':
+      stop()
       timerId = setInterval(postMessage.bind(null, 'tick'), 25)
-    } else if (e.data === 'stop') {
-      clearInterval(timerId)
-      timerId = null
+      break
+
+    case 'stop':
+      stop() 
+      break
     }
   }
 }


### PR DESCRIPTION
Fixes #1

Ensure the interval is cleared before starting in case start is called twice